### PR TITLE
Pass test info for android

### DIFF
--- a/fixture.js
+++ b/fixture.js
@@ -94,7 +94,7 @@ exports.test = base.test.extend({
           )}`
         );
         await vDevice.shell("am force-stop com.android.chrome");
-        vContext = await vDevice.launchBrowser();
+        vContext = await vDevice.launchBrowser(testInfo.project.use);
       } else {
         patchCaps(testInfo.project.name, `${testInfo.title}`);
         delete caps.osVersion;


### PR DESCRIPTION
Params such as `baseUrl` weren't being honoured from `playwright.config.js` as the `testInfo` wasn't being passed during context creation.