### PR TITLE
Add hardened .npmrc for supply-chain security

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,7 @@
+# Supply-chain hardening directives (SC-12282 / APS-19732)
+ignore-scripts=true
+strict-ssl=true
+save-exact=true
+engine-strict=true
+legacy-peer-deps=false
+audit-level=high


### PR DESCRIPTION
Adds a hardened `.npmrc` enforcing npm supply-chain best practices:

```ini
ignore-scripts=true
strict-ssl=true
save-exact=true
engine-strict=true
legacy-peer-deps=false
audit-level=high
```

Notes:
- `ignore-scripts=true` skips this package's own postinstall (`npm update browserstack-node-sdk`), so the SDK stays pinned to the lockfile version — more reproducible installs.
- Verified: `npm ci` against the committed package-lock.json on Node 18, 20, and 22 (Node 16 unsupported by current Playwright) — lockfile unchanged; sample test run verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
